### PR TITLE
Feature #18105 Add WYSIWIG editor for incident notes

### DIFF
--- a/packaging/rpm/Gemfile_web
+++ b/packaging/rpm/Gemfile_web
@@ -157,6 +157,8 @@ gem 'i18n-js','=3.6.0'
 
 gem 'acts_as_list', '=1.1.0'
 
+gem 'trix-rails', '=2.4.0'
+
 gem 'brakeman','=3.6.1', group: [:development, :test]
 
 group :development do


### PR DESCRIPTION
## Related issue in RedMine

[Feature #18105](https://redmine.redborder.lan/issues/18105)

## Description

This new gem give us the possibility to create a rich text editor in the web.

## Detail

The gem `trix-rails`, version `2.4.0` was added in the `Gemfile_web`.