### PR TITLE
bugfix/#18870_install_gems_in_global_gemset_needed_for_scripts_using_web_gemset

### DIFF
--- a/packaging/rpm/Gemfile_global
+++ b/packaging/rpm/Gemfile_global
@@ -1,4 +1,4 @@
-source 'http://geminabox.redborder.com'
+source 'https://geminabox.redborder.com'
 # source 'https://rubygems.org'
 
 # redborder-ng basic gems
@@ -29,4 +29,5 @@ gem 'easycache', "=0.0.2"
 gem 'pg', '=1.5.4'
 gem 'iso8601', '=0.8.7'
 gem 'nokogiri' #, '=1.7.0'
-gem 'aws-sdk-v1', '=1.61.0'
+gem 'aws-sdk', '=1.61.0'
+gem 'aws-s3', '=0.6.3'

--- a/packaging/rpm/Gemfile_global
+++ b/packaging/rpm/Gemfile_global
@@ -26,3 +26,7 @@ gem 'ffi-rzmq', '2.0.6'
 gem "dalli", "= 2.7.10"
 gem 'ilo-sdk'
 gem 'easycache', "=0.0.2"
+gem 'pg', '=1.5.4'
+gem 'iso8601', '=0.8.7'
+gem 'nokogiri' #, '=1.7.0'
+gem 'aws-sdk-v1', '=1.61.0'

--- a/packaging/rpm/Gemfile_web
+++ b/packaging/rpm/Gemfile_web
@@ -1,4 +1,4 @@
-source 'http://geminabox.redborder.com'
+source 'https://geminabox.redborder.com'
 # source 'https://rubygems.org'
 
 # Rails 5 new required gem

--- a/packaging/rpm/download_makerpm_gems.sh
+++ b/packaging/rpm/download_makerpm_gems.sh
@@ -12,7 +12,7 @@ GEMS=(
 )
 
 # Define the host URL
-GEMINABOX_HOST="http://geminabox.redborder.com/gems/"
+GEMINABOX_HOST="https://geminabox.redborder.com/gems/"
 
 # Define the target directory
 TARGET_DIR="${SCRIPT_DIR}/SOURCES"


### PR DESCRIPTION
## Related issue in RedMine

[#18870_install_gems_in_global_gemset_needed_for_scripts_using_web_gemset](https://redmine.redborder.lan/issues/18870)

## Description / Motivation

System Scripts should'nt change the gemset and use web gemset.

## Detail

rb_clean_segments and rb_druid_rules needs some gem already installed at gemset web but we need to use global.

