### PR TITLE
Remove wicked_pdf

### DIFF
--- a/packaging/rpm/Gemfile_web
+++ b/packaging/rpm/Gemfile_web
@@ -135,8 +135,6 @@ gem 'pg', '=1.5.4'
 
 gem 'ditto_code', '=0.3.5'
 
-gem 'wicked_pdf', '=1.4.0'
-
 gem 'grover', '=1.1.3'
 
 gem 'rmagick', '=2.16.0'

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -55,6 +55,7 @@ srpm: build_prepare
 rpm: srpm
 	/usr/bin/mock \
 		-r $(MOCK_CONFIG) \
+		--enable-network \
 		--define "__version $(VERSION)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--define "__rvmdir $(RVMDIR)" \


### PR DESCRIPTION
This task focuses on switching the mail report generation gem from wicked_pdf to Grover, creating a report historical record when a report is mailed, removing wicked_pdf and changing the mailing template so the report isn't attached but a link to the historical record is attached instead.

Redmine ticket: https://redmine.redborder.lan/issues/20852